### PR TITLE
Revert line item decorator changes

### DIFF
--- a/app/async/async_base.rb
+++ b/app/async/async_base.rb
@@ -18,7 +18,9 @@ class AsyncBase
   def really_a_newgistics_error?(response)
     not_really_errors = [
         'This shipment has already been canceled.',
-        'This shipment has already been returned.'
+        'This shipment has already been returned.',
+        'Shipment with status \'CANCELED\' cannot be updated',
+        'Shipment with status \'RETURNED\' cannot be updated'
     ]
     error = parse_errors(response)
     success = Nokogiri::XML(response.body).xpath('//success').text == 'true'

--- a/app/async/async_base.rb
+++ b/app/async/async_base.rb
@@ -11,16 +11,18 @@ class AsyncBase
     raise e
   end
 
-  def update_success?(response)
-    response.status <= 299 && !really_a_newgistics_error?(response)
+  def update_success?(response,  order_number = nil)
+    response.status <= 299 && !really_a_newgistics_error?(response, order_number)
   end
 
-  def really_a_newgistics_error?(response)
+  def really_a_newgistics_error?(response, order_number)
     not_really_errors = [
         'This shipment has already been canceled.',
         'This shipment has already been returned.',
         'Shipment with status \'CANCELED\' cannot be updated',
-        'Shipment with status \'RETURNED\' cannot be updated'
+        'Shipment with status \'RETURNED\' cannot be updated',
+        'Shipment with status \'SHIPPED\' cannot be updated',
+        "Multiple shipments matching order ID '#{order_number}' found. Please update this shipment using the Newgistics Fulfillment Management Console instead."
     ]
     error = parse_errors(response)
     success = Nokogiri::XML(response.body).xpath('//success').text == 'true'

--- a/app/async/async_base.rb
+++ b/app/async/async_base.rb
@@ -22,6 +22,7 @@ class AsyncBase
         'Shipment with status \'CANCELED\' cannot be updated',
         'Shipment with status \'RETURNED\' cannot be updated',
         'Shipment with status \'SHIPPED\' cannot be updated',
+        'Shipment with status \'VERIFIED\' cannot be updated'
         "Multiple shipments matching order ID '#{order_number}' found. Please update this shipment using the Newgistics Fulfillment Management Console instead."
     ]
     error = parse_errors(response)

--- a/app/async/workers/order_address_updater.rb
+++ b/app/async/workers/order_address_updater.rb
@@ -6,7 +6,7 @@ module Workers
       order = Spree::Order.find(order_id)
       document = Spree::Newgistics::DocumentBuilder.build_shipment_updated_address(order)
       response = Spree::Newgistics::HTTPManager.post('/update_shipment_address.aspx', document)
-      if update_success?(response)
+      if update_success?(response, order.number)
         order.update_column(:newgistics_status, 'UPDATED')
       else
         raise "Negistics error, response status: #{response.status} errors: #{parse_errors(response)}"

--- a/app/async/workers/order_contents_updater.rb
+++ b/app/async/workers/order_contents_updater.rb
@@ -7,7 +7,7 @@ module Workers
         order = Spree::Order.find(order_id)
         document = Spree::Newgistics::DocumentBuilder.build_shipment_contents(order.number, sku, qty, add)
         response = Spree::Newgistics::HTTPManager.post('/update_shipment_contents.aspx', document)
-        if update_success?(response)
+        if update_success?(response, order.number)
           order.update_column(:newgistics_status, 'UPDATED')
         else
           raise "Negistics error, response status: #{response.status} errors: #{parse_errors(response)}"

--- a/app/async/workers/order_status_updater.rb
+++ b/app/async/workers/order_status_updater.rb
@@ -8,7 +8,7 @@ module Workers
       if should_update_newgistics_state?(order, state_change) && can_update_newgistics_state?(order, state_change)
         document = Spree::Newgistics::DocumentBuilder.build_shipment_updated_state(state_change)
         response = Spree::Newgistics::HTTPManager.post('/update_shipment_address.aspx', document)
-        if update_success?(response)
+        if update_success?(response, order.number)
           order.update_column(:newgistics_status, state_change.newgistics_status)
         else
           raise "Negistics error, response status: #{response.status} errors: #{parse_errors(response)}"

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,18 +1,30 @@
 Spree::LineItem.class_eval do
 
-  alias_method :old_update_inventory, :update_inventory
+  after_create :add_to_newgistics_shipment_contents, if: lambda {|line_item| line_item.order.can_update_newgistics? }
 
-  def update_inventory
-    sync_to_newgistics if self.order.can_update_newgistics?
-    old_update_inventory    
+  after_destroy :remove_from_newgistics_shipment_contents, if: lambda {|line_item| line_item.order.can_update_newgistics? }
+
+  after_update :update_newgistics_shipment_contents, if: lambda { |line_item| line_item.quantity_changed? && line_item.order.can_update_newgistics?}
+
+
+  ## after a line item is added to the order and if the order state is completed, update newgistics   ## shipment.
+  def add_to_newgistics_shipment_contents(qty = self.quantity)
+    order.add_newgistics_shipment_content(variant.sku, qty)
   end
 
-  def sync_to_newgistics
-    diff = self.quantity - self.inventory_units.size
-    if diff > 0
-      order.add_newgistics_shipment_content(variant.sku, diff)
+  ## after a line item is removed to the order and if the order state is completed update newgistics  ## shipment.
+  def remove_from_newgistics_shipment_contents(qty = self.quantity)
+    order.remove_newgistics_shipment_content(variant.sku, qty)
+  end
+
+  ## If line items quantities change and the order state is completed, update newgistics shipment
+  def update_newgistics_shipment_contents
+    old_value = changes[:quantity][0]
+    new_value = changes[:quantity][1]
+    if old_value > new_value
+      remove_from_newgistics_shipment_contents(old_value - new_value)
     else
-      order.remove_newgistics_shipment_content(variant.sku, diff.abs)
+      add_to_newgistics_shipment_contents(new_value - old_value)
     end
   end
 end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -19,12 +19,12 @@ Spree::Order.class_eval do
 
   ## This method is called whenever order contents are updated, this is triggered on the after update callback for line items quantity
   def add_newgistics_shipment_content(sku, qty)
-    Workers::OrderContentsUpdater.perform_async self.id, sku, qty, add = true
+    Workers::OrderContentsUpdater.perform_async(self.id, sku, qty, add = true) if complete?
   end
 
   ## This method is called whenever order contents are updated, this is triggered on the after update callback for line items quantity
   def remove_newgistics_shipment_content(sku, qty)
-    Workers::OrderContentsUpdater.perform_async self.id, sku, qty, add = false
+    Workers::OrderContentsUpdater.perform_async(self.id, sku, qty, add = false) if complete?
   end
 
   ## This method posts the order to newgisitcs as soon as the checkout ends, if using auto capture


### PR DESCRIPTION
I noticed a few errors in sidekiq queue that I've never seen before

```RuntimeError: Negistics error, response status: 200 errors: Unable to process product removal for SKU 'BL3208'; the quantity given is more than exists in the shipment```

So I reverted changes to it, since shipments are not being updated and we are shipping orders with more items that they should have.