### PR TITLE
Duplicated orders are posted to Newgistics

### DIFF
--- a/app/async/workers/order_poster.rb
+++ b/app/async/workers/order_poster.rb
@@ -2,7 +2,9 @@ module Workers
   class OrderPoster < AsyncBase
     include Sidekiq::Worker
 
-    sidekiq_options retry: 3
+    sidekiq_options retry: 3,
+                    unique: true,
+                    unique_args: ->(args) { [ args.first ] }
 
     def perform(order_id)
       order = Spree::Order.find(order_id)

--- a/app/async/workers/order_poster.rb
+++ b/app/async/workers/order_poster.rb
@@ -15,7 +15,6 @@ module Workers
         document = Spree::Newgistics::DocumentBuilder.build_shipment(order.shipments)
         response = Spree::Newgistics::HTTPManager.post('/post_shipments.aspx', document)
         if update_success?(response, order.number)
-          errors = Nokogiri::XML(response.body).css('errors').children
           log << "NG responded with status #{response.status}, processing order\n"
           order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
           log.close

--- a/app/async/workers/order_poster.rb
+++ b/app/async/workers/order_poster.rb
@@ -14,22 +14,17 @@ module Workers
         log << "Order is being sent to Newgistics\n"
         document = Spree::Newgistics::DocumentBuilder.build_shipment(order.shipments)
         response = Spree::Newgistics::HTTPManager.post('/post_shipments.aspx', document)
-        if response.status <= 299
+        if update_success?(response, order.number)
           errors = Nokogiri::XML(response.body).css('errors').children
-          if !errors.any?
-            log << "NG responded with status #{response.status}, processing order\n"
-            order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
-          else
-            log << "NG responded with status #{response.status} with errors:\n"
-            errors.each { |e| log << "#{e}\n" }
-          end
+          log << "NG responded with status #{response.status}, processing order\n"
+          order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
           log.close
-        elsif response.status > 399
-          log << "NG responded with status #{response.status}\n"
-          log.close
-          raise "Newgistics response failed, status: #{response.status}"
         else
+          errors = Nokogiri::XML(response.body).css('errors').children
+          log << "NG responded with status #{response.status} and response has errors\n"
+          errors.each { |e| log << "#{e} \n" }
           log.close
+          raise "Newgistics response failed, status: #{response.status} and response has errors"
         end
       else
         log << "Order is alredy sent to Newgistics\n"

--- a/app/async/workers/order_poster.rb
+++ b/app/async/workers/order_poster.rb
@@ -7,25 +7,30 @@ module Workers
     def perform(order_id)
       order = Spree::Order.find(order_id)
       log = File.open("#{Rails.root}/log/#{order.number}_#{Time.now.to_s.gsub(/\s/, "_")}_newgistics_order_poster.log", 'a')
-      log << "#{Time.now}"
-      log << "Posting order #{order.id} with number #{order.number}"
-      document = Spree::Newgistics::DocumentBuilder.build_shipment(order.shipments)
-      response = Spree::Newgistics::HTTPManager.post('/post_shipments.aspx', document)
-      if response.status <= 299
-        errors = Nokogiri::XML(response.body).css('errors').children
-        if !errors.any?
-          log << "NG responded with status #{response.status}, processing order"
-          order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
+      log << "#{Time.now} - Posting order #{order.id} with number #{order.number}\n"
+      if !order.posted_to_newgistics
+        log << "Order is being sent to Newgistics\n"
+        document = Spree::Newgistics::DocumentBuilder.build_shipment(order.shipments)
+        response = Spree::Newgistics::HTTPManager.post('/post_shipments.aspx', document)
+        if response.status <= 299
+          errors = Nokogiri::XML(response.body).css('errors').children.any?
+          if !errors
+            log << "NG responded with status #{response.status}, processing order\n"
+            order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
+          else
+            log << "NG responded with status #{response.status} with errors:\n"
+            errors.each { |e| log << "#{e}\n" }
+          end
+          log.close
+        elsif response.status > 399
+          log << "NG responded with status #{response.status}\n"
+          log.close
+          raise "Newgistics response failed, status: #{response.status}"
         else
-          log << "NG responded with status #{response.status} with errors:"
-          errors.each { |e| puts e }
+          log.close
         end
-        log.close
-      elsif response.status > 399
-        log << "NG responded with status #{response.status}"
-        log.close
-        raise "Newgistics response failed, status: #{response.status}"
       else
+        log << "Order is alredy sent to Newgistics\n"
         log.close
       end
     end

--- a/app/async/workers/order_poster.rb
+++ b/app/async/workers/order_poster.rb
@@ -13,8 +13,8 @@ module Workers
         document = Spree::Newgistics::DocumentBuilder.build_shipment(order.shipments)
         response = Spree::Newgistics::HTTPManager.post('/post_shipments.aspx', document)
         if response.status <= 299
-          errors = Nokogiri::XML(response.body).css('errors').children.any?
-          if !errors
+          errors = Nokogiri::XML(response.body).css('errors').children
+          if !errors.any?
             log << "NG responded with status #{response.status}, processing order\n"
             order.update_attributes({posted_to_newgistics: true, newgistics_status: 'RECEIVED'})
           else

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,1 +1,4 @@
 require 'sidekiq'
+require 'sidekiq-unique-jobs'
+
+SidekiqUniqueJobs.config.unique_args_enabled = true

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -103,6 +103,18 @@ describe Spree::Order do
       expect(line_item.reload.quantity).to eq(qty+1)
     end
 
+    it 'starts status sync on order cancelation' do
+      order.stub(:posted_to_newgistics?).and_return true
+      Workers::OrderStatusUpdater.should_receive(:perform_async).at_least(:once)
+      order.cancel!
+    end
+
+    it 'don\'t start status sync on order cancelation if order is not posted to newgistics' do
+      order.stub(:posted_to_newgistics?).and_return false
+      Workers::OrderStatusUpdater.should_not_receive(:perform_async)
+      order.cancel!
+    end
+
   end
 
   context 'failed requests' do

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -115,7 +115,7 @@ describe Spree::Order do
     end
 
     it 'fails posting the order to newgistics' do
-      order.post_to_newgistics
+      expect { order.post_to_newgistics }.to raise_error(RuntimeError)
       expect(order.posted_to_newgistics).to be_falsy
     end
 

--- a/spree_newgistics.gemspec
+++ b/spree_newgistics.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sidekiq'
   s.add_dependency 'sidekiq-cron', '~> 0.2.0'
   s.add_dependency 'sidekiq-status'
+  s.add_dependency 'sidekiq-unique-jobs'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'

--- a/spree_newgistics.gemspec
+++ b/spree_newgistics.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'mock_redis'
 end


### PR DESCRIPTION
This code prevents multiple order posting to Newgistics in two ways:
- when background job is started, it checks if order was already posted to Newgistics and only then starts to send data;
- sidekiq-unique-job prevents creating multiple jobs with same argument (order id) in the same time preventing creation of race condition on posted_to_newgistics flag;