### PR TITLE
Bug: ProductsPuller sometimes creates duplicate SKUs

### DIFF
--- a/app/async/workers/products_puller.rb
+++ b/app/async/workers/products_puller.rb
@@ -57,11 +57,20 @@ module Workers
           else
             color_code = product['sku'].match(/-([^-]*)$/).try(:[],1).to_s
 
+
             ## if sku has color code it means we need to build and group variants together
             if color_code.present?
               attach_to_master(product, spree_variants, item_category_id, log)
             else
-              create_with_master(product, item_category_id, log)
+              # Check if a master variant was created in a previous run
+              master_variant_sku = "#{product['sku']}-00"
+              master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
+              
+              if master_variant
+                attach_to_master(product, spree_variants, item_category_id, log)
+              else
+                create_with_master(product, item_category_id, log)
+              end
             end
             log << "SUCCESS: created sku: #{product['sku']}\n"
           end
@@ -170,7 +179,7 @@ module Workers
       ## build a master variant sku which would be the same color code with 0000
       product_code = product['sku'].match(/^(.*)-/)[1].to_s
       master_variant_sku = "#{product_code}-00"
-      master_variant = spree_variants.find { |variant| variant.sku == master_variant_sku && variant.is_master }
+      master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
 
       ## if we already have a master variant it means a product has been created
       ## let's just add a new variant to the product.

--- a/app/async/workers/products_puller.rb
+++ b/app/async/workers/products_puller.rb
@@ -33,12 +33,11 @@ module Workers
         hash[:categories] << p["supplier"]
       end
 
-      spree_variants = Spree::Variant.where(sku: data[:skus])
       spree_categories = Spree::ItemCategory.where(name: data[:categories])
 
       products.each_with_index do |product, index|
         begin
-          spree_variant = spree_variants.find { |sv| sv.sku == product['sku'] }
+          spree_variant = Spree::Variant.find_by_sku(product['sku'])
 
           item_category_id = nil
           if product['supplier'].present?
@@ -60,14 +59,14 @@ module Workers
 
             ## if sku has color code it means we need to build and group variants together
             if color_code.present?
-              attach_to_master(product, spree_variants, item_category_id, log)
+              attach_to_master(product, item_category_id, log)
             else
               # Check if a master variant was created in a previous run
               master_variant_sku = "#{product['sku']}-00"
               master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
               
               if master_variant
-                attach_to_master(product, spree_variants, item_category_id, log)
+                attach_to_master(product, item_category_id, log)
               else
                 create_with_master(product, item_category_id, log)
               end
@@ -175,7 +174,7 @@ module Workers
       spree_variant.product.save!
     end
 
-    def attach_to_master(product, spree_variants, item_category_id, log)
+    def attach_to_master(product, item_category_id, log)
       ## build a master variant sku which would be the same color code with 0000
       product_code = product['sku'].match(/^(.*)-/)[1].to_s
       master_variant_sku = "#{product_code}-00"

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe Spree::Order do
 
+  before(:each) do
+    Spree::Variant.any_instance.stub(:ensure_color_code)
+    Spree::Variant.any_instance.stub(:enqueue_product_for_reindex)
+  end
+
   success_adapter = Faraday.new do |builder|
     builder.adapter :test do |stub|
       post_shipment = File.read(File.expand_path('spec/faraday/post_shipment.txt'))

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe Spree::Order do
 
+  before(:each) do
+    Spree::Variant.any_instance.stub(:ensure_color_code)
+    Spree::Variant.any_instance.stub(:enqueue_product_for_reindex)
+  end
+
   success_adapter = Faraday.new do |builder|
     builder.adapter :test do |stub|
       post_product = File.read(File.expand_path('spec/faraday/post_product.txt'))

--- a/spec/workers/inventory_puller_spec.rb
+++ b/spec/workers/inventory_puller_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe Workers::InventoryPuller do
+  before(:each) do
+    Spree::Variant.any_instance.stub(:ensure_color_code)
+    Spree::Variant.any_instance.stub(:enqueue_product_for_reindex)
+  end
+
   describe "#update_inventory" do
     context "when variant's stock items change from 0 to greater than 0" do
 

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -40,7 +40,7 @@ describe Workers::ProductsPuller do
     end
 
     context "with existing master variant" do
-      let(:master_variant) { create :variant, sku: 'CYN6000-00' }
+      let(:master_variant) { create :variant, sku: 'CYN6000-00', is_master: true }
 
       let(:response) do [{
         'sku' => 'CYN6000',

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -39,6 +39,70 @@ describe Workers::ProductsPuller do
       end
     end
 
+    context "with existing master variant" do
+      let(:master_variant) { create :variant, sku: 'CYN6000-00' }
+
+      let(:response) do [{
+        'sku' => 'CYN6000',
+        'description' => 'SKU with master already in DB',
+        'upc' => '123',
+        'value' => '12.99',
+        'retailValue' => '10.99',
+        'height' => '1',
+        'width' => '2',
+        'weight' => '3',
+        'depth' => '4',
+        'isActive' => 'true'
+      }] end
+
+      context "and no matching variant" do
+        it "should create this variant and attach it to the master" do
+          category_id = 1
+          stub_const("Spree::ItemCategory", fake_category)
+          Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
+          Spree::ItemCategory.stub(:where).and_return([])
+
+          master_variant
+
+          expect(subject).to receive(:attach_to_master)
+          expect(subject).not_to receive(:create_with_master)
+          subject.save_products(response)
+        end
+      end
+
+      context "and a matching variant" do
+        let(:variant) { create :variant, sku: 'CYN6000-02' }
+
+        let(:response) do [{
+          'sku' => 'CYN6000-02',
+          'description' => 'SKU with master already in DB',
+          'upc' => '123',
+          'value' => '12.99',
+          'retailValue' => '10.99',
+          'height' => '1',
+          'width' => '2',
+          'weight' => '3',
+          'depth' => '4',
+          'isActive' => 'true'
+        }] end
+
+        it "should update the variant" do
+          category_id = 1
+          stub_const("Spree::ItemCategory", fake_category)
+          Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
+          Spree::ItemCategory.stub(:where).and_return([])
+
+          master_variant
+          variant
+
+          expect(subject).to receive(:update_variant)
+          expect(subject).not_to receive(:attach_to_master)
+          expect(subject).not_to receive(:create_with_master)
+          subject.save_products(response)
+        end
+      end
+    end
+
     context "not exisitng variant with color code" do
       let(:response) do [{
         'sku' => 'AB468-123',


### PR DESCRIPTION
- [x] Add tests for the case when duplicate SKUs are created
  - This happens when an Admin has created the master in the site Admin before the import is started
- [x] Add check for master SKU before deciding when to attach to a master
- [x] Get tests to be green