### PR TITLE
SKU without color code should create new product

### DIFF
--- a/app/async/workers/products_puller.rb
+++ b/app/async/workers/products_puller.rb
@@ -97,7 +97,7 @@ module Workers
           end
         rescue StandardError => e
           log << "ERROR: sku: #{product['sku']} failed due to: #{e.message}\n"
-          log << e.backtrace.join("\n") + "\n"
+          log << e.backtrace.join("\n")
         end
         progress_at(step * (index + 1)) if index % 5 == 0
       end
@@ -201,7 +201,7 @@ module Workers
 
     def attach_to_master(product, item_category_id, log)
       ## build a master variant sku which would be the same color code with 0000
-      code = product_code(product['sku'])
+      code = product_code(product)
       master_variant_sku = "#{code}-00"
       master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
 
@@ -264,7 +264,8 @@ module Workers
     end
 
     def color_code_present?(product)
-      product['sku'].match(/-([^-]*)$/).try(:[],1).to_s.present?
+      color_code = product['sku'].match(/-([^-]*)$/).try(:[],1).to_s
+      color_code.present?
     end
   end
 end

--- a/app/async/workers/products_puller.rb
+++ b/app/async/workers/products_puller.rb
@@ -64,7 +64,7 @@ module Workers
               # Check if a master variant was created in a previous run
               master_variant_sku = "#{product['sku']}-00"
               master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
-              
+
               if master_variant
                 attach_to_master(product, item_category_id, log)
               else
@@ -179,7 +179,7 @@ module Workers
 
     def attach_to_master(product, item_category_id, log)
       ## build a master variant sku which would be the same color code with 0000
-      product_code = product['sku'].match(/^(.*)-/)[1].to_s
+      product_code = product_code(product['sku'])
       master_variant_sku = "#{product_code}-00"
       master_variant = Spree::Variant.find { |variant| variant.sku == master_variant_sku && variant.is_master }
 
@@ -228,6 +228,14 @@ module Workers
       spree_product.variants << additional_variant
       spree_product.save!
       master.update_attributes!({ sku: "#{product['sku']}-00" })
+    end
+
+    def product_code(product)
+      if product['sku'].match(/^(.*)-/)
+        product['sku'].match(/^(.*)-/)[1].to_s
+      else
+        product['sku']
+      end
     end
   end
 end

--- a/app/async/workers/products_puller.rb
+++ b/app/async/workers/products_puller.rb
@@ -219,13 +219,10 @@ module Workers
         spree_product = Spree::Product.new(get_attributes_from(product))
         log << "creating  master sku for grouping: #{master_variant_sku}...\n"
         spree_product.master.assign_attributes(variant_attributes_from(product).merge({ sku: master_variant_sku, is_master: true }))
-        log << spree_product.inspect
 
         log << "1# creating color code: #{ product['sku'] } for master sku: #{master_variant_sku}...\n"
         spree_variant = Spree::Variant.new(get_attributes_from(product))
         spree_variant.assign_attributes(variant_attributes_from(product).merge({item_category_id: item_category_id, is_master: false }))
-
-        log << spree_variant.inspect
 
         spree_variant.save!
 

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -41,20 +41,33 @@ describe Workers::ProductsPuller do
     context "with existing master variant" do
       let(:master_variant) { create :variant, sku: 'CYN6000-00', is_master: true }
 
-      let(:response) do [{
-        'sku' => 'CYN6000-01',
-        'description' => 'SKU with master already in DB',
-        'upc' => '123',
-        'value' => '12.99',
-        'retailValue' => '10.99',
-        'height' => '1',
-        'width' => '2',
-        'weight' => '3',
-        'depth' => '4',
-        'isActive' => 'true'
-      }] end
-
       context "and no matching variant" do
+        let(:response) do [{
+          'sku' => 'CYN6000-01',
+          'description' => 'SKU with master already in DB',
+          'upc' => '123',
+          'value' => '12.99',
+          'retailValue' => '10.99',
+          'height' => '1',
+          'width' => '2',
+          'weight' => '3',
+          'depth' => '4',
+          'isActive' => 'true'
+        }] end
+
+        let(:colorless_response) do [{
+          'sku' => 'CYN6000',
+          'description' => 'SKU with master already in DB',
+          'upc' => '123',
+          'value' => '12.99',
+          'retailValue' => '10.99',
+          'height' => '1',
+          'width' => '2',
+          'weight' => '3',
+          'depth' => '4',
+          'isActive' => 'true'
+        }] end
+
         it "should create this variant and attach it to the master" do
           category_id = 1
           stub_const("Spree::ItemCategory", fake_category)
@@ -66,6 +79,19 @@ describe Workers::ProductsPuller do
           expect(subject).to receive(:attach_to_master)
           expect(subject).not_to receive(:create_with_master)
           subject.save_products(response)
+        end
+
+        it "should create this variant and attach it to the master" do
+          category_id = 1
+          stub_const("Spree::ItemCategory", fake_category)
+          Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
+          Spree::ItemCategory.stub(:where).and_return([])
+
+          master_variant
+
+          expect(subject).to receive(:attach_to_master)
+          expect(subject).not_to receive(:create_with_master)
+          subject.save_products(colorless_response)
         end
       end
 

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -285,9 +285,7 @@ describe Workers::ProductsPuller do
         'sku' => 'RAN1-05'
       } end
 
-      it "should not raise error" do
-        expect{ subject.product_code(product) }.not_to raise_error
-      end
+      it { expect{ subject.product_code(product) }.not_to raise_error }
 
       it "should return base" do
         expect( subject.product_code(product) ).to eq(product['sku'].split('-')[0])
@@ -299,11 +297,9 @@ describe Workers::ProductsPuller do
         'sku' => 'RAN1'
       } end
 
-      it "should not raise error" do
-        expect { subject.product_code(product) }.not_to raise_error
-      end
+      it { expect { subject.product_code(product) }.not_to raise_error }
 
-      it "should return base sku" do
+      it "should return SKU" do
         expect( subject.product_code(product) ).to eq(product['sku'])
       end
     end

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -81,7 +81,7 @@ describe Workers::ProductsPuller do
           subject.save_products(response)
         end
 
-        it "should create this variant and attach it to the master" do
+        it "should create this variant and attach it to the master for colorless SKU" do
           category_id = 1
           stub_const("Spree::ItemCategory", fake_category)
           Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -135,8 +135,8 @@ describe Workers::ProductsPuller do
 
     context "not exisitng variant without color code" do
       let(:response) do [{
-        'sku' => 'AB468',
-        'description' => 'test - sku',
+        'sku' => 'REN5',
+        'description' => 'new SKU without color code',
         'upc' => '123',
         'value' => '12.99',
         'retailValue' => '10.99',
@@ -148,12 +148,12 @@ describe Workers::ProductsPuller do
       }] end
 
       it "should attach new variant to master" do
-        category_id = 1
-        stub_const("Spree::ItemCategory", fake_category)
-        Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
-        Spree::ItemCategory.stub(:where).and_return([])
+        # category_id = 1
+        # stub_const("Spree::ItemCategory", fake_category)
+        # Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
+        # Spree::ItemCategory.stub(:where).and_return([])
 
-        expect(subject).to receive(:create_with_master)
+        expect(subject).to receive(:create_product)
         subject.save_products(response)
       end
     end

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -148,12 +148,12 @@ describe Workers::ProductsPuller do
       }] end
 
       it "should attach new variant to master" do
-        # category_id = 1
-        # stub_const("Spree::ItemCategory", fake_category)
-        # Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
-        # Spree::ItemCategory.stub(:where).and_return([])
+        category_id = 1
+        stub_const("Spree::ItemCategory", fake_category)
+        Spree::ItemCategory.stub(:find_or_create_by!).and_return(Spree::ItemCategory.new(category_id))
+        Spree::ItemCategory.stub(:where).and_return([])
 
-        expect(subject).to receive(:create_product)
+        expect(subject).to receive(:create_with_master)
         subject.save_products(response)
       end
     end
@@ -276,6 +276,36 @@ describe Workers::ProductsPuller do
       variant.stub(:newgistics_active=)
 
       expect { subject.update_variant(product, variant, [], nil, nil) }.not_to raise_error
+    end
+  end
+
+  describe "#product_code" do
+    context "product code with color code" do
+      let(:product) do {
+        'sku' => 'RAN1-05'
+      } end
+
+      it "should not raise error" do
+        expect{ subject.product_code(product) }.not_to raise_error
+      end
+
+      it "should return base" do
+        expect( subject.product_code(product) ).to eq(product['sku'].split('-')[0])
+      end
+    end
+
+    context "product code without color code" do
+      let(:product) do {
+        'sku' => 'RAN1'
+      } end
+
+      it "should not raise error" do
+        expect { subject.product_code(product) }.not_to raise_error
+      end
+
+      it "should return base sku" do
+        expect( subject.product_code(product) ).to eq(product['sku'])
+      end
     end
   end
 end

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -42,7 +42,7 @@ describe Workers::ProductsPuller do
       let(:master_variant) { create :variant, sku: 'CYN6000-00', is_master: true }
 
       let(:response) do [{
-        'sku' => 'CYN6000',
+        'sku' => 'CYN6000-01',
         'description' => 'SKU with master already in DB',
         'upc' => '123',
         'value' => '12.99',

--- a/spec/workers/products_puller_spec.rb
+++ b/spec/workers/products_puller_spec.rb
@@ -308,4 +308,22 @@ describe Workers::ProductsPuller do
       end
     end
   end
+
+  describe "#color_code_present?" do
+    context "product code with color code" do
+      let(:product) do {
+        'sku' => 'RAN1-05'
+      } end
+
+      it { expect( subject.color_code_present?(product)).to be_truthy }
+    end
+
+    context "product code without color code" do
+      let(:product) do {
+        'sku' => 'RAN1'
+      } end
+
+      it { expect( subject.color_code_present?(product)).to be_falsy }
+    end
+  end
 end


### PR DESCRIPTION
The reason for this PR is an error when new product with colorless SKU is created ('ABC123' without '-01'). Error occurs in product code parsing phase.

- [x] rewrite tests to test all cases for a new product
- [x] get tests to be green
- [x] write a description of product import process