### PR TITLE
Fix issue when count_of_hand becames negative

### DIFF
--- a/app/async/workers/orders_puller.rb
+++ b/app/async/workers/orders_puller.rb
@@ -98,8 +98,6 @@ module Workers
             order_shipped = order.changed.include?("newgistics_status") && order.newgistics_status == "SHIPPED"
             order.save!
 
-            log << "Order cancel #{order_canceled}\n"
-            log << "Order shipped #{order_shipped}\n"
             order.cancel!(:send_email => "true") if order_canceled
             if order_shipped
               order.shipments.update_all({tracking: shipment['Tracking'],

--- a/app/async/workers/orders_puller.rb
+++ b/app/async/workers/orders_puller.rb
@@ -64,12 +64,12 @@ module Workers
 
           state_id = states[shipment['State']].try(:id)
           if state_id.nil?
-            log << "Could not find the state with abbreviation=%s when processing order %s" % [shipments['State'], order.number]
+            log << "Could not find the state with abbreviation=%s when processing order %s\n" % [shipments['State'], order.number]
           end
 
           country_id = countries[shipment['Country']].try(:id)
           if country_id.nil?
-            log << "Could not find the country %s when processing order %s" % [shipments['Country'], order.number]
+            log << "Could not find the country %s when processing order %s\n" % [shipments['Country'], order.number]
           end
 
           attributes = {
@@ -98,6 +98,8 @@ module Workers
             order_shipped = order.changed.include?("newgistics_status") && order.newgistics_status == "SHIPPED"
             order.save!
 
+            log << "Order cancel #{order_canceled}\n"
+            log << "Order shipped #{order_shipped}\n"
             order.cancel!(:send_email => "true") if order_canceled
             if order_shipped
               order.shipments.update_all({tracking: shipment['Tracking'],

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,0 +1,5 @@
+Spree::Shipment.class_eval do
+  def after_cancel
+    manifest.each { |item| manifest_restock(item) } unless self.order.posted_to_newgistics
+  end
+end

--- a/spec/common/out_of_stock_spec.rb
+++ b/spec/common/out_of_stock_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe "out_of_stock" do
+  before(:each) do
+    Spree::Variant.any_instance.stub(:ensure_color_code)
+    Spree::Variant.any_instance.stub(:enqueue_product_for_reindex)
+    Spree::Order.any_instance.stub(:send_product_review_email)
+    Spree::Order.any_instance.stub(:update_newgistics_shipment_address)
+    Spree::Order.any_instance.stub(:update_newgistics_shipment_status)
+  end
+
+  context "when OrdersPuller executed after InventoryPuller for canceled order" do
+
+    let(:order) { create(:order_ready_to_be_completed, :line_items_count => 1) }
+
+    let(:cancel_response) do 
+        a = order.ship_address
+        resp = [{
+          'OrderID' => order.number,
+          'FirstName' => a.firstname,
+          'LastName' => a.lastname,
+          'Address1' => a.address1,
+          'Address2' => a.address2,
+          'City' => a.city,
+          'State' => a.state.abbr,
+          'Company' => a.company.to_s,
+          'PostalCode' => a.zipcode,
+          'Country' => a.country.iso_name,
+          'Phone' => a.phone,
+          'ShipmentStatus' => 'CANCELED'
+        }] 
+    end
+
+    let(:inventory_response) do [
+        {
+          "id" => "1148187",
+          "sku" => order.line_items.first.variant.sku,
+          "currentQuantity"=> "1",
+          "receivingQuantity"=> "0",
+          "arrivedPutAwayQuantity"=>"0",
+          "kittingQuantity"=>"0",
+          "returnsQuantity"=>"0",
+          "pendingQuantity"=>"0",
+          "availableQuantity"=> "1",
+          "backorderedQuantity"=>"0"
+        }] 
+    end
+
+    it "pre check order is created well" do
+      expect(order.line_items.size).to eq(1)
+      li = order.line_items.first
+      expect(li.quantity).to eq(1)
+      expect(li.variant.reload.stock_items.count).to eq(1)
+
+
+      si = li.variant.stock_items.first
+      expect(si.stock_location_id).to eq(1)
+      expect(si.count_on_hand).to eq(1)
+      expect(order.shipments.size).to eq(1)
+      expect(order.shipments.first.manifest.size).to eq(1)
+      expect(order.shipments.first.manifest.first.quantity).to eq(1)
+      expect(order.shipments.first.manifest.first.variant).to eq(li.variant)
+    end
+
+    it "should not increase counf of items twice" do
+      si = order.line_items.first.variant.stock_items.first 
+      expect(si.count_on_hand).to eq(1)
+      5.times do 
+        order.next
+      end
+      expect(order.state).to eq('complete')
+      expect(si.reload.count_on_hand).to eq(0)
+
+      # post order to NG than cancel it from NG
+      order.posted_to_newgistics = true
+      order.save
+      # Run inventory puller
+      Workers::InventoryPuller.new.update_inventory(inventory_response)
+      expect(si.reload.count_on_hand).to eq(1)
+
+      # Run orders puller
+      Workers::OrdersPuller.new.update_shipments(cancel_response)
+      order.reload
+      expect(order.newgistics_status).to eq('CANCELED')
+      expect(order.state).to eq('canceled')
+      expect(si.reload.count_on_hand).to eq(1)
+    end
+       
+  end
+end

--- a/spec/common/out_of_stock_spec.rb
+++ b/spec/common/out_of_stock_spec.rb
@@ -62,7 +62,7 @@ describe "out_of_stock" do
       expect(order.shipments.first.manifest.first.variant).to eq(li.variant)
     end
 
-    it "should not increase counf of items twice" do
+    it "should not increase count of items twice" do
       si = order.line_items.first.variant.stock_items.first 
       expect(si.count_on_hand).to eq(1)
       5.times do 

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -1,0 +1,35 @@
+require 'spree/testing_support/factories'
+
+FactoryGirl.define do
+
+  factory :order_ready_to_be_completed, parent: :order do
+    bill_address
+    ship_address
+    state 'cart'
+
+    transient do
+      line_items_count 1
+    end
+
+    after(:create) do |order, evaluator|
+      variant = create :variant
+      variant.stock_items.first.set_count_on_hand evaluator.line_items_count
+
+      create_list(:line_item, evaluator.line_items_count, order: order, variant: variant)
+      order.line_items.reload
+
+      create(:shipment, order: order)
+      order.shipments.reload
+
+      order.refresh_shipment_rates
+      create(:payment, amount: order.total, order: order)
+
+      order.update!
+
+      variant.stock_items.delete(variant.stock_items.last)
+      variant.stock_items.reload
+    end
+
+
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ require 'spree_newgistics/factories'
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  FactoryGirl.find_definitions
 
   # Infer an example group's spec type from the file location.
   config.infer_spec_type_from_file_location!

--- a/spec/workers/orders_puller_spec.rb
+++ b/spec/workers/orders_puller_spec.rb
@@ -4,6 +4,14 @@ describe Workers::OrdersPuller do
 
   describe "#update_shipments" do
 
+    before(:each) do
+      Spree::Variant.any_instance.stub(:ensure_color_code)
+      Spree::Variant.any_instance.stub(:enqueue_product_for_reindex)
+      Spree::Order.any_instance.stub(:send_product_review_email)
+      Spree::Order.any_instance.stub(:update_newgistics_shipment_address)
+      Spree::Order.any_instance.stub(:update_newgistics_shipment_status)
+    end
+
     context "when newgistics status differs" do
       let(:order) { create :order, newgistics_status: 'ONVHOLD', state: 'complete' }
       let(:response) do [{


### PR DESCRIPTION
Issue:
0. Available items of some SKU is 1
1. Submit order with that item to NG, than cancel it at NG side
2. NG increase available items by 1, spree has 0 `count_on_hand`
3. InventoryPuller job increase `count_on_hand` (spree side) by 1
4. Than OrdersPuller cancel the order at spree side, which again increase `count_on_hand` by 1
5. Profit! We have `count_on_hand` bigger than real available items we have